### PR TITLE
Use the newest node-font-face-generator which is asynchronous.

### DIFF
--- a/lib/font-middleware.js
+++ b/lib/font-middleware.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const
-css_generator = require("node-font-face-generator");
+css_generator      = require("node-font-face-generator"),
+InvalidFontError   = css_generator.InvalidFontError;
 
 /*
  * Used as a GET request handler. The requested language is expected to be in
@@ -18,20 +19,23 @@ exports.font_css_responder = function(req, res, next) {
       fonts = req.params.fonts && req.params.fonts.split(',');
 
   if (ua && lang && fonts) {
-    try {
-      var cssStr = css_generator.get_font_css({
-        ua: ua,
-        lang: lang,
-        fonts: fonts
-      });
-
-      res.setHeader('Content-Type', 'text/css', 'text/css; charset=utf8');
-      res.send(cssStr, 200);
-    }
-    catch(e) {
-      // If the font is unknown, call the next middleware
-      if(e.toString().indexOf("invalid font") > -1) next();
-    }
+    var cssStr = css_generator.get_font_css({
+      ua: ua,
+      lang: lang,
+      fonts: fonts
+    }, function(err, cssStr) {
+      if (err && err instanceof InvalidFontError) {
+        next();
+      }
+      else if (err) {
+        // do nothing, this is an invalid config or a missing config. Let
+        // a higher level deal with this situation.
+      }
+      else {
+        res.setHeader('Content-Type', 'text/css', 'text/css; charset=utf8');
+        res.send(cssStr, 200);
+      }
+    });
   }
   else {
     next();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "index",
   "dependencies": {
-    "node-font-face-generator": ">=0.0.3"
+    "node-font-face-generator": "0.0.4"
   },
   "devDependencies": {
     "nodeunit": ">=0.6.4"


### PR DESCRIPTION
Involves no changes to the unit tests.
